### PR TITLE
Add an option to (not) replace the mdata and ram directories

### DIFF
--- a/source-code/data/plugins/config_template.bin
+++ b/source-code/data/plugins/config_template.bin
@@ -88,6 +88,8 @@ Card=0
 Hardware_Slider=0
 #Enable custom patches
 Custom_Patches=1
+#Replace mdata and ram directories
+replace_mdata_ram_dir=1
 
 [Graphics]
 # Lag Compensation

--- a/source-code/source/plugins/Launcher/framework.h
+++ b/source-code/source/plugins/Launcher/framework.h
@@ -272,6 +272,7 @@ ConfigOptionBase* optionsArray[] = {
 	//new BooleanOption(L"ignore_exe_checksum", PATCHES_SECTION, CONFIG_FILE, L"Ignore exe checksum", L"Use at your own risk.", false, false),
 	new StringOption(L"command_line", LAUNCHER_SECTION, CONFIG_FILE, L"Command Line:", L"Allows setting command line parameters for the game when using the launcher.\nDisabling the launcher will bypass this.", L"", false),
 	new BooleanOption(L"use_divahook_bat", LAUNCHER_SECTION, CONFIG_FILE, L"Use divahook.bat/start.bat", L"Launches divahook.bat/start.bat intead of diva.exe.", false, false),
+	new BooleanOption(L"replace_mdata_ram_dir", LAUNCHER_SECTION, CONFIG_FILE, L"Replace mdata and ram directories", L"Sets the mdata directory to mdata/ and the ram directory to the game directory.\nDo not turn it off unless you're using the SegaTools.", true, false),
 };
 
 ConfigOptionBase* playerdataArray[] = {

--- a/source-code/source/plugins/Launcher/framework.h
+++ b/source-code/source/plugins/Launcher/framework.h
@@ -272,7 +272,7 @@ ConfigOptionBase* optionsArray[] = {
 	//new BooleanOption(L"ignore_exe_checksum", PATCHES_SECTION, CONFIG_FILE, L"Ignore exe checksum", L"Use at your own risk.", false, false),
 	new StringOption(L"command_line", LAUNCHER_SECTION, CONFIG_FILE, L"Command Line:", L"Allows setting command line parameters for the game when using the launcher.\nDisabling the launcher will bypass this.", L"", false),
 	new BooleanOption(L"use_divahook_bat", LAUNCHER_SECTION, CONFIG_FILE, L"Use divahook.bat/start.bat", L"Launches divahook.bat/start.bat intead of diva.exe.", false, false),
-	new BooleanOption(L"replace_mdata_ram_dir", LAUNCHER_SECTION, CONFIG_FILE, L"Replace mdata and ram directories", L"Sets the mdata directory to mdata/ and the ram directory to the game directory.\nDo not turn it off unless you're using the SegaTools.", true, false),
+	new BooleanOption(L"replace_mdata_ram_dir", PATCHES_SECTION, CONFIG_FILE, L"Replace mdata and ram directories", L"Sets the mdata directory to mdata/ and the ram directory to the game directory.\nDo not turn it off unless you're using the SegaTools.", true, false),
 };
 
 ConfigOptionBase* playerdataArray[] = {

--- a/source-code/source/plugins/Patches/PatchApplier600.h
+++ b/source-code/source/plugins/Patches/PatchApplier600.h
@@ -17,11 +17,6 @@ class PatchApplier600 : public PatchApplier {
 			// Ignore the EngineClear variable to clear the framebuffer at all resolutions
 			{ (void*)0x00000001404E7470, { 0x90, 0x90 } },
 			{ (void*)0x00000001404E7505, { 0x90, 0x90 } },
-			// Write ram files to the current directory instead of Y : / SBZV / ram
-			{ (void*)0x0000000140648AE9, { 0xE9, 0xD8, 0x00 } },
-			// Change mdata path from "C:/Mount/Option" to "mdata/"
-			{ (void*)0x0000000140A51058, { 0x6D, 0x64, 0x61, 0x74, 0x61, 0x2F, 0x00 } },
-			{ (void*)0x0000000140648A8E, { 0x06 } },
 			// Skip parts of the network check state
 			{ (void*)0x000000014064D391, { 0xE9, 0x22, 0x03, 0x00 } },
 			// Set the initial DHCP WAIT timer value to 0
@@ -73,6 +68,14 @@ class PatchApplier600 : public PatchApplier {
 			InjectCode(patches_600[i].Address, patches_600[i].Data);
 
 
+		if (nReplaceMdataRamDir)
+		{
+			// Write ram files to the current directory instead of Y : / SBZV / ram
+			InjectCode((void*)0x0000000140648AE9, { 0xE9, 0xD8, 0x00 });
+			// Change mdata path from "C:/Mount/Option" to "mdata/"
+			InjectCode((void*)0x0000000140A51058, { 0x6D, 0x64, 0x61, 0x74, 0x61, 0x2F, 0x00 });
+			InjectCode((void*)0x0000000140648A8E, { 0x06 });
+		}
 		
 		// The old stereo patch...
 		// Use 2 channels instead of 4

--- a/source-code/source/plugins/Patches/PatchApplier710.h
+++ b/source-code/source/plugins/Patches/PatchApplier710.h
@@ -17,11 +17,6 @@ class PatchApplier710 : public PatchApplier {
 			// Ignore the EngineClear variable to clear the framebuffer at all resolutions
 			{ (void*)0x0000000140501480, { 0x90, 0x90 } },
 			{ (void*)0x0000000140501515, { 0x90, 0x90 } },
-			// Write ram files to the current directory instead of Y : / SBZV / ram
-			{ (void*)0x000000014066CF09, { 0xE9, 0xD8, 0x00 } },
-			// Change mdata path from "C:/Mount/Option" to "mdata/"
-			{ (void*)0x0000000140A8CA18, { 0x6D, 0x64, 0x61, 0x74, 0x61, 0x2F, 0x00 } },
-			{ (void*)0x000000014066CEAE, { 0x06 } },
 			// Skip parts of the network check state
 			{ (void*)0x00000001406717B1, { 0xE9, 0x22, 0x03, 0x00 } },
 			// Set the initial DHCP WAIT timer value to 0
@@ -74,7 +69,15 @@ class PatchApplier710 : public PatchApplier {
 		for (size_t i = 0; i < _countof(patches_710); i++)
 			InjectCode(patches_710[i].Address, patches_710[i].Data);
 
-
+		
+		if (nReplaceMdataRamDir)
+		{
+			// Write ram files to the current directory instead of Y : / SBZV / ram
+			InjectCode((void*)0x000000014066CF09, { 0xE9, 0xD8, 0x00 });
+			// Change mdata path from "C:/Mount/Option" to "mdata/"
+			InjectCode((void*)0x0000000140A8CA18, { 0x6D, 0x64, 0x61, 0x74, 0x61, 0x2F, 0x00 });
+			InjectCode((void*)0x000000014066CEAE, { 0x06 });
+		}
 
 		// The old stereo patch...
 		// Use 2 channels instead of 4

--- a/source-code/source/plugins/Patches/framework.h
+++ b/source-code/source/plugins/Patches/framework.h
@@ -147,4 +147,4 @@ auto nShadowResWidth = GetPrivateProfileIntW(L"graphics", L"shadow_res_width", 2
 auto nShadowResHeight = GetPrivateProfileIntW(L"graphics", L"shadow_res_height", 2048, CONFIG_FILE);
 auto nLagCompensation = GetPrivateProfileIntW(L"graphics", L"lag_compensation", 0, CONFIG_FILE);
 auto nUseDivahookBat = GetPrivateProfileIntW(L"launcher", L"use_divahook_bat", FALSE, CONFIG_FILE);
-auto nReplaceMdataRamDir = GetPrivateProfileIntW(L"launcher", L"replace_mdata_ram_dir", TRUE, CONFIG_FILE);
+auto nReplaceMdataRamDir = GetPrivateProfileIntW(L"patches", L"replace_mdata_ram_dir", TRUE, CONFIG_FILE);

--- a/source-code/source/plugins/Patches/framework.h
+++ b/source-code/source/plugins/Patches/framework.h
@@ -147,3 +147,4 @@ auto nShadowResWidth = GetPrivateProfileIntW(L"graphics", L"shadow_res_width", 2
 auto nShadowResHeight = GetPrivateProfileIntW(L"graphics", L"shadow_res_height", 2048, CONFIG_FILE);
 auto nLagCompensation = GetPrivateProfileIntW(L"graphics", L"lag_compensation", 0, CONFIG_FILE);
 auto nUseDivahookBat = GetPrivateProfileIntW(L"launcher", L"use_divahook_bat", FALSE, CONFIG_FILE);
+auto nReplaceMdataRamDir = GetPrivateProfileIntW(L"launcher", L"replace_mdata_ram_dir", TRUE, CONFIG_FILE);


### PR DESCRIPTION
Fixes #23 but needs testing with SegaTools.